### PR TITLE
changed from local variable to root_url

### DIFF
--- a/frontend/react/src/api/ApiRootUrl.ts
+++ b/frontend/react/src/api/ApiRootUrl.ts
@@ -4,7 +4,7 @@ const ROOT_URL = "https://ca-noq-backend.thankfulglacier-35d24b26.swedencentral.
 const local = "http://localhost:8080/"
 
 const api: AxiosInstance = axios.create({
-  baseURL: local,
+  baseURL: ROOT_URL,
 });
 
 export default api;


### PR DESCRIPTION
Local variable were left unchanged during development. This needed to be changed in order for the deploy to work online.