### PR TITLE
Adding account key for Cosmos DB to backend env variables

### DIFF
--- a/.github/workflows/noq_deployment.yml
+++ b/.github/workflows/noq_deployment.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   # Verify build of frontend
   build-frontend:
@@ -67,10 +71,12 @@ jobs:
         uses: actions/checkout@v3
 
       # Authenticate with Azure Cloud
-      - name: "Log into Azure"
+      - name: "OIDC Login to Azure"
         uses: Azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: true
 
       # Create formatted timestamp to use as deployment name
@@ -142,7 +148,7 @@ jobs:
           region: swedencentral
           template: ./infrastructure/noq-backend-app.bicep
           deploymentName: "noq_be_${{ steps.date.outputs.ts }}"
-          parameters: 'registryPassword=${{ env.registryPassword }} registryUsername=${{ env.registryUsername }} registry=${{ steps.arm.outputs.registryLoginServer }} envShortName=${{ vars.ENV_SHORTNAME }} appName="noq-backend" containerEnvironment=${{ steps.arm.outputs.containerEnvironmentName }} containerImage=${{ steps.arm.outputs.registryLoginServer }}/backend/noq-backend:${{ github.sha }} targetPort=8080 allowedOrigin=${{ steps.frontend.outputs.containerFqdn }} cosmosDbAccountName=${{ steps.arm.outputs.cosmosDbAccountName }} cosmosDbAccountEndpoint=${{ steps.arm.outputs.cosmosDbAccountEndpoint }}'
+          parameters: 'registryPassword=${{ env.registryPassword }} registryUsername=${{ env.registryUsername }} registry=${{ steps.arm.outputs.registryLoginServer }} envShortName=${{ vars.ENV_SHORTNAME }} appName="noq-backend" containerEnvironment=${{ steps.arm.outputs.containerEnvironmentName }} containerImage=${{ steps.arm.outputs.registryLoginServer }}/backend/noq-backend:${{ github.sha }} targetPort=8080 allowedOrigin=${{ steps.frontend.outputs.containerFqdn }} cosmosDbAccountName=${{ steps.arm.outputs.cosmosDbAccountName }} cosmosDbAccountEndpoint=${{ steps.arm.outputs.cosmosDbAccountEndpoint }} keyVaultResourceName=${{ steps.arm.outputs.keyVaultName }} keyVaultSecretName=${{ steps.arm.outputs.keyVaultName }} cosmosDbAccountKeySecretName=${{ steps.arm.outputs.cosmosDbAccountKeySecretName }}'
           failOnStdErr: false
 
       # Provision container app for user-client

--- a/infrastructure/noq-infrastructure-main.bicep
+++ b/infrastructure/noq-infrastructure-main.bicep
@@ -121,3 +121,4 @@ output keyVaultName string = keyVault.outputs.keyVaultName
 output containerEnvironmentName string = containerAppEnv.outputs.resourceName
 output cosmosDbAccountName string = cosmosDbAccount.outputs.resourceName
 output cosmosDbAccountEndpoint string = cosmosDbAccount.outputs.accountUrl
+output cosmosDbAccountKeySecretName string = cosmosDbAccount.outputs.primaryKeySecretName

--- a/infrastructure/resource-templates/container-app-template.bicep
+++ b/infrastructure/resource-templates/container-app-template.bicep
@@ -23,7 +23,25 @@ param allowedOrigins array = []
 
 param environmentVariables array = []
 
+@secure()
+param cosmosDbAccountKey string = ''
+
 var corsPolicy = empty(allowedOrigins) ? null : allowedOrigins
+
+
+var baseSecrets = [
+  {
+    name: 'registry-password'
+    value: registryPassword
+  }
+]
+
+var cosmosKeySecret = empty(cosmosDbAccountKey) ? null : {
+  name: 'cosmos-account-key'
+  value: cosmosDbAccountKey
+}
+
+var allSecrets = concat(baseSecrets, array(cosmosKeySecret))
 
 // Reference the managed environment resource
 resource environment 'Microsoft.App/managedEnvironments@2022-10-01' existing = {
@@ -40,12 +58,7 @@ resource containerApp 'Microsoft.App/containerApps@2022-10-01' ={
   properties:{
     managedEnvironmentId: environment.id
     configuration: {
-      secrets: [
-        {
-          name: 'registry-password'
-          value: registryPassword
-        }
-      ]
+      secrets: allSecrets
       ingress: {
         corsPolicy: {
           allowedOrigins: corsPolicy!

--- a/noq-backend/README.md
+++ b/noq-backend/README.md
@@ -47,7 +47,7 @@ is an example of how to connect to Cosmos DB using the managed identity of the c
 CosmosAsyncClient Client=new CosmosClientBuilder().endpoint("<account-endpoint>").credential(new ManagedIdentityCredential()).build();
 ```
 
-The account endpoint can be read from environment variable `COSMOS_DB_ACCOUNT_ENDPOINT`.
+The account endpoint can be read from environment variable `COSMOS_DB_ACCOUNT_NAME`.
 
 ### Development tools
 


### PR DESCRIPTION
- Changed login to Azure to use OIDC instead of client id and secret during deployment. Takes away the need for key-rotation in GitHub

- Changed deployment of backend app to now also include the Cosmos DB account key as an environment variable. This is temporary why we work on adding support for using System Assigned Managed Identity to authenticate with Cosmos DB resource.