### PR TITLE
Temporarily disable shelter booking feature for demo and soft launch

### DIFF
--- a/frontend/user-client/src/components/available-hosts/AvailableHosts.tsx
+++ b/frontend/user-client/src/components/available-hosts/AvailableHosts.tsx
@@ -51,6 +51,20 @@ const BookingsPage = (props: BookingsProps) => {
       <div>
         <main className={"flex mt-1 xxs:justify-center md:justify-start"}>
           <div className={"flex flex-col w-11/12 gap-1"}>
+            <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">
+              <div className="flex">
+                <div className="flex-shrink-0">
+                  <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd"/>
+                  </svg>
+                </div>
+                <div className="ml-3">
+                  <p className="text-sm text-yellow-700">
+                    The shelter booking feature is temporarily disabled for the demo and soft launch.
+                  </p>
+                </div>
+              </div>
+            </div>
 
             <section aria-label={"select-area"} className={"md:w-5/12 lg:w-4/12"}>
               <select id="countries"

--- a/frontend/user-client/src/components/available-hosts/components/AvailableBookingItem.tsx
+++ b/frontend/user-client/src/components/available-hosts/components/AvailableBookingItem.tsx
@@ -45,13 +45,9 @@ const AvailableBookingItem = (props: RequestItemProps) => {
               {props.availableHost.countOfAvailablePlaces}
             </p>
             <div className="text-right mt-4">
-              <Link href={`/booking/${props.availableHost.hostId}`}>
-                <Button1
-                  title={"Välj boställe"}
-                  isLoading={isLoading}
-                  onClick={() => onClickHost(props.availableHost.hostId)}
-                />
-              </Link>
+              <div className="bg-gray-100 p-2 rounded text-sm text-gray-600">
+                Booking temporarily disabled
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/user-client/src/components/my-bookings/MyBookingsPage.tsx
+++ b/frontend/user-client/src/components/my-bookings/MyBookingsPage.tsx
@@ -19,6 +19,20 @@ const MyBookingsPage = (props: RequestsProps) => {
       <div>
         <main className={"flex mt-1 xxs:justify-center md:justify-start"}>
           <div className={"flex flex-col w-11/12"}>
+            <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">
+              <div className="flex">
+                <div className="flex-shrink-0">
+                  <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd"/>
+                  </svg>
+                </div>
+                <div className="ml-3">
+                  <p className="text-sm text-yellow-700">
+                    The shelter booking feature is temporarily disabled for the demo and soft launch.
+                  </p>
+                </div>
+              </div>
+            </div>
             {bookingViewModel ? <>
               <div className={"flex flex-col gap-1"}>
                 {bookingViewModel && bookingViewModel.bookings && bookingViewModel.bookings.map(request => {

--- a/noq-backend/src/main/java/com/noq/backend/clients/host/bookings/BookingsPageController.java
+++ b/noq-backend/src/main/java/com/noq/backend/clients/host/bookings/BookingsPageController.java
@@ -24,30 +24,24 @@ public class BookingsPageController {
     private final UserService userService;
 
     @GetMapping
-    // FIXME to @GetMapping("/{hostId}") after removing Hardcoding of 550e8400-e29b-41d4-a716-446655440000
-    public ResponseEntity<BookingsPageDTO> getBookingsPageForHost(/*@PathVariable String hostId*/) {
-        log.info("Loading BookingsPageDTO");
-        // TODO Remove this Hardcoding. Frontend should send correct hostId
-        String hostId = "550e8400-e29b-41d4-a716-446655440000";
-        // FIXME Error when Host does not exist
-        BookingsPageDTO dto = toDTO(hostId);
-        return ResponseEntity.ok(dto);
+    public ResponseEntity<BookingsPageDTO> getBookingsPageForHost() {
+        log.info("getBookingsPageForHost - Feature temporarily disabled");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(new BookingsPageDTO(List.of()));
     }
 
     @PostMapping("approve")
     public ResponseEntity<BookingsPageDTO> approve(@RequestBody BookingApprovalReqBody reqBody) {
-        String hostId = "550e8400-e29b-41d4-a716-446655440000";
-        bookingService.decideApproval(UUID.fromString(reqBody.bookingId()), ApprovalStatus.APPROVE);
-        var dto = toDTO(hostId);
-        return ResponseEntity.ok(dto);
+        log.info("approve - Feature temporarily disabled");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(new BookingsPageDTO(List.of()));
     }
 
     @PostMapping("deny")
     public ResponseEntity<BookingsPageDTO> deny(@RequestBody BookingApprovalReqBody reqBody) {
-        String hostId = "550e8400-e29b-41d4-a716-446655440000";
-        bookingService.decideApproval(UUID.fromString(reqBody.bookingId()), ApprovalStatus.DENY);
-        var dto = toDTO(hostId);
-        return ResponseEntity.ok(dto);
+        log.info("deny - Feature temporarily disabled");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(new BookingsPageDTO(List.of()));
     }
 
     private BookingsPageDTO.BookingDTO toDTO(Booking booking) {
@@ -65,17 +59,6 @@ public class BookingsPageController {
                 // FIXME Implementation for Queuing of Bookings
                 .queuingPlace(0)
                 .status(booking.getBookingStatus().name())
-                .build();
-    }
-
-    private BookingsPageDTO toDTO(String hostId) {
-        List<Booking> allBookingsForHost = bookingService.findBookingsForHost(UUID.fromString(hostId));
-        return BookingsPageDTO.builder()
-                .id(hostId)
-                .approvedBookings(allBookingsForHost.stream()
-                        .filter(booking -> booking.getBookingStatus() == BookingStatus.APPROVED).map(this::toDTO).toArray(BookingsPageDTO.BookingDTO[]::new))
-                .disapprovedBookings(allBookingsForHost.stream().filter(booking -> booking.getBookingStatus() == BookingStatus.DENIED).map(this::toDTO).toArray(BookingsPageDTO.BookingDTO[]::new))
-                .pendingBookings(allBookingsForHost.stream().filter(booking -> booking.getBookingStatus() == BookingStatus.PENDING).map(this::toDTO).toArray(BookingsPageDTO.BookingDTO[]::new))
                 .build();
     }
 }

--- a/noq-backend/src/main/java/com/noq/backend/clients/user/booking/UserBookingController.java
+++ b/noq-backend/src/main/java/com/noq/backend/clients/user/booking/UserBookingController.java
@@ -31,39 +31,38 @@ public class UserBookingController {
 
     @GetMapping("{hostId}")
     public ResponseEntity<UserBookingPageDTO> getBookingPage(@PathVariable UUID hostId) {
-        log.info("getBookingPage");
-        log.info("hostId: {}", hostId);
-        UserBookingPageDTO toDTO = buildDTO(hostId);
-        return ResponseEntity.ok(toDTO);
+        log.info("getBookingPage - Feature temporarily disabled");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(new UserBookingPageDTO(
+                        "550e8400-e29b-41d4-a716-446655440011",
+                        hostId.toString(),
+                        "Feature Temporarily Disabled",
+                        "N/A",
+                        "N/A",
+                        "N/A",
+                        "N/A",
+                        0,
+                        0));
     }
 
     @PutMapping("create-booking")
     public ResponseEntity<String> createBooking(@RequestBody UserCreateBookingRequestDTO reqBody) {
-        log.info("createBooking");
-        log.info("reqBody: {}", reqBody);
-        try {
-            var booking = bookingService.createBooking(UUID.fromString(reqBody.hostId()), UUID.fromString(userId), LocalDateTime.now());
-            return ResponseEntity.ok("Booking created with ID: " + booking.getBookingId());
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
-        }
+        log.info("createBooking - Feature temporarily disabled");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body("Shelter booking feature is temporarily disabled for the demo and soft launch.");
     }
 
     @GetMapping("/user/{userId}")
     public List<Booking> findBookingsForUser(@PathVariable UUID userId) {
-        log.info("Finding Bookings for UserId: {}", userId);
-        return bookingService.findBookingsForUser(userId);
+        log.info("findBookingsForUser - Feature temporarily disabled");
+        return List.of();
     }
 
     @PostMapping("/user/{userId}/cancel/{bookingId}")
     public ResponseEntity<String> cancel(@PathVariable UUID userId, @PathVariable UUID bookingId) {
-        try {
-            // TODO Don't Cancel Booking if Does not belong to this User
-            bookingService.cancelBooking(bookingId);
-            return ResponseEntity.ok("Booking approval status updated successfully.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
-        }
+        log.info("cancel - Feature temporarily disabled");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body("Shelter booking feature is temporarily disabled for the demo and soft launch.");
     }
 
     public UserBookingPageDTO buildDTO(UUID hostId) {
@@ -83,18 +82,16 @@ public class UserBookingController {
                 dtoBuilder.getHost().getAddressPostcode(),
                 dtoBuilder.getHost().getCity(),
                 dtoBuilder.getHost().getCountOfAvailablePlaces(),
-                dtoBuilder.getHost().getTotalPlaces()
-        );
+                dtoBuilder.getHost().getTotalPlaces());
     }
 
     @Data
     static class DTOBuilder {
-//        User user;
+        // User user;
         Host host;
 
-//        public DTOBuilder(User user) {
-//            this.user = user;
-//        }
+        // public DTOBuilder(User user) {
+        // this.user = user;
+        // }
     }
 }
-

--- a/noq-backend/src/main/java/com/noq/backend/services/BookingServiceImpl.java
+++ b/noq-backend/src/main/java/com/noq/backend/services/BookingServiceImpl.java
@@ -9,6 +9,8 @@ import com.noq.backend.repositories.UserRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,71 +33,34 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     public Booking createBooking(UUID hostId, UUID userId, LocalDateTime startDateTime) {
-        // Assume that User Always Exists FIXME User Administration UI and Backend & errorHandling in case User Does not Exist
-        var user = userRepository.findById(userId).orElseThrow();
-        log.info("Creating a Booking for user {}", user.getUserId());
-
-        // Check if host exists and is available
-        var availableHost = hostRepository.findById(hostId)
-                // Check if Vacant Places exist on the Host
-                .filter(host -> host.getCountOfAvailablePlaces() > 0)
-                .orElseThrow(() -> new HostNotFoundException(hostId.toString()));
-
-        // Add to Queue of Pending Requests (this does not decrement available count on Host)
-        return bookingRepository.save(Booking.builder()
-                .userId(user.getUserId())
-                .hostId(availableHost.getHostId())
-                .bookingStatus(BookingStatus.PENDING)
-                .approvalStatus(ApprovalStatus.PENDING)
-                .startDateTime(startDateTime)
-                // FIXME What is Correct Duration of booking for someone to stay in? defaulting to 8 hours
-                .endDateTime(startDateTime.plusHours(HOURS_UNTIL_BOOKING_ENDS))
-                .caseManagerName("Handläggare Namn")
-                .caseManagerEmail("handlaggare@noq.se")
-                .build());
+        log.info("createBooking - Feature temporarily disabled");
+        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                "Shelter booking feature is temporarily disabled for the demo and soft launch.");
     }
 
     @Override
     public void decideApproval(UUID bookingId, ApprovalStatus approvalStatusToBeUpdated) {
-        bookingRepository.findById(bookingId)
-                .map(booking -> {
-                    var currentApprovalStatus = booking.getApprovalStatus();
-                    if (currentApprovalStatus == ApprovalStatus.PENDING) {
-                        switch (approvalStatusToBeUpdated) {
-                            case APPROVE -> booking = booking.toBuilder()
-                                    .bookingStatus(BookingStatus.APPROVED)
-                                    .approvalStatus(approvalStatusToBeUpdated)
-                                    .build();
-                            case DENY -> booking = booking.toBuilder()
-                                    .bookingStatus(BookingStatus.DENIED)
-                                    .approvalStatus(approvalStatusToBeUpdated)
-                                    .build();
-                            case PENDING -> log.info("No change in Approval Status");
-                        }
-                    } else {
-                        throw new IllegalStateException("Cannot change Approval status once APPROVED or DENIED. Create a new Reservation.");
-                    }
-                    return bookingRepository.save(booking);
-                })
-                .orElseThrow(() -> new RuntimeException("Booking Not Found"));
+        log.info("decideApproval - Feature temporarily disabled");
+        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                "Shelter booking feature is temporarily disabled for the demo and soft launch.");
     }
 
     @Override
     public void cancelBooking(UUID bookingId) {
-        throw new RuntimeException("NOT IMPLEMENTED cancelBooking");
+        log.info("cancelBooking - Feature temporarily disabled");
+        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                "Shelter booking feature is temporarily disabled for the demo and soft launch.");
     }
 
     @Override
     public List<Booking> findBookingsForHost(UUID hostId) {
-        List<Booking> bookingsByHostId = bookingRepository.findAllByHostId(hostId);
-//        log.info("Found {} bookings for HostId {}", bookingsByHostId.size(), hostId);
-        return bookingsByHostId;
+        log.info("findBookingsForHost - Feature temporarily disabled");
+        return List.of();
     }
 
     @Override
     public List<Booking> findBookingsForUser(UUID userId) {
-        List<Booking> bookingsByUserId = bookingRepository.findAllByUserId(userId);
-        log.info("Found {} bookings for UserId {}", bookingsByUserId.size(), userId);
-        return bookingsByUserId;
+        log.info("findBookingsForUser - Feature temporarily disabled");
+        return List.of();
     }
 }


### PR DESCRIPTION
This PR temporarily disables the shelter/accommodation booking functionality for the demo and soft launch phase of the platform. This change ensures that volunteers cannot see or make bookings for accommodation at shelters, and help org admins cannot access this function either.