### PR TITLE
templates for epic and user story links updated

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-user-story-template.md
+++ b/.github/ISSUE_TEMPLATE/1-user-story-template.md
@@ -1,38 +1,41 @@
 ---
 name: 1-User story template
-about: A story is a new requirement for a feature that provides direct value to the
+about:
+  A story is a new requirement for a feature that provides direct value to the
   end user of it. Probably a slice of an epic.
-title: 'STORY: '
-labels: ''
-assignees: ''
-
+title: "STORY: "
+labels: ""
+assignees: ""
 ---
 
 **Story**
 As a [user] i need to [action/title of this story] so i can [value].
 
 **Acceptance Criteria (checklist)**
-- [ ]  One
-- [ ]  Two
-- [ ]  Three
+
+- [ ] One
+- [ ] Two
+- [ ] Three
 
 **Acceptance Criteria (BDD)**
 
 AC1:
-* Given [status/place]
-* When [action]
-* Then [result/output]
+
+- Given [status/place]
+- When [action]
+- Then [result/output]
 
 AC2:
-* Given [status/place]
-* When [action]
-* Then [result/output]
 
-**Other info:** 
+- Given [status/place]
+- When [action]
+- Then [result/output]
+
+**Other info:**
 Ex: Links, Solutions, best practices etc.
 
-- [ ]  **Definition of Ready OK?**
-Also called DoR, our generic process for checking if this is ready for start. See our Playbook here for details: https://docs.google.com/document/d/1ou6wr1sI9IJZaGGSMn_SJvFru5FJQKMDRZY16kBmx5Y/edit#heading=h.3rdcrjn
+- [ ] **Definition of Ready OK?**
+      Also called DoR, our generic process for checking if this is ready for start. See our Playbook here for details: [Playbook 2.3 - DOR ](https://docs.google.com/document/d/1nbKJWM_FspoZzlSmbCFTnHwqOSiT1lfsvzozmtopduY/edit?tab=t.0#heading=h.3rdcrjn)
 
-- [ ]  **Definition of Done OK?**
-Also called DoD, our generic process for checking this is done in the right way. See our Playbook here for details: https://docs.google.com/document/d/1ou6wr1sI9IJZaGGSMn_SJvFru5FJQKMDRZY16kBmx5Y/edit#heading=h.23ckvvd
+- [ ] **Definition of Done OK?**
+      Also called DoD, our generic process for checking this is done in the right way. See our Playbook here for details: [Playbook 2.3 - DOD](https://docs.google.com/document/d/1nbKJWM_FspoZzlSmbCFTnHwqOSiT1lfsvzozmtopduY/edit?tab=t.0#heading=h.23ckvvd)

--- a/.github/ISSUE_TEMPLATE/2-epic-template.md
+++ b/.github/ISSUE_TEMPLATE/2-epic-template.md
@@ -1,11 +1,11 @@
 ---
 name: 2-Epic template
-about: Epics are big planning items that we slice into work items (stories). For each
+about:
+  Epics are big planning items that we slice into work items (stories). For each
   slice we create a subissue.
-title: 'EPIC: '
-labels: ''
-assignees: ''
-
+title: "EPIC: "
+labels: ""
+assignees: ""
 ---
 
 **Hypothesis**
@@ -15,25 +15,27 @@ Our solution will make sure [the user] gets [future state/outcome].
 We know this is true when the following metrics has been ticked off:
 
 **Metrics**
-- [ ]  X% [impact] latest YYMMDD
+
+- [ ] X% [impact] latest YYMMDD
 
 **Acceptance Criteria**
-* Given we have all metrics measured
-* When we look attt the output
-* Then we can decide if this hypothesis was true or false
 
-**Other info:** 
+- Given we have all metrics measured
+- When we look attt the output
+- Then we can decide if this hypothesis was true or false
+
+**Other info:**
 Ex: Links, Solutions, best practices etc.
 
-- [ ]  **Definition of Ready OK?**
-Also called DoR, our generic process for checking if this is ready for start. See our Playbook here for details: https://docs.google.com/document/d/1ou6wr1sI9IJZaGGSMn_SJvFru5FJQKMDRZY16kBmx5Y/edit#heading=h.3rdcrjn
+- [ ] **Definition of Ready OK?**
+      Also called DoR, our generic process for checking if this is ready for start. See our Playbook here for details: [Playbook 2.3 - DOR ](https://docs.google.com/document/d/1nbKJWM_FspoZzlSmbCFTnHwqOSiT1lfsvzozmtopduY/edit?tab=t.0#heading=h.3rdcrjn)
 
-- [ ]  **Definition of Done OK?**
-Also called DoD, our generic process for checking this is done in the right way. See our Playbook here for details: https://docs.google.com/document/d/1ou6wr1sI9IJZaGGSMn_SJvFru5FJQKMDRZY16kBmx5Y/edit#heading=h.23ckvvd
+- [ ] **Definition of Done OK?**
+      Also called DoD, our generic process for checking this is done in the right way. See our Playbook here for details: [Playbook 2.3 - DOD](https://docs.google.com/document/d/1nbKJWM_FspoZzlSmbCFTnHwqOSiT1lfsvzozmtopduY/edit?tab=t.0#heading=h.23ckvvd)
 
-- [ ]  **Trinity Approach**
-These three people are responsible for the lifecycle of the epic:
-UX / QA: A desirable solution, one what your customer really needs.
-Tech/Architect Expert: A feasible solution, building on the strengths of your current operational capabilities.
-PO: A viable (profitable) solution, with a sustainable business model.
-https://docs.google.com/document/d/1nbKJWM_FspoZzlSmbCFTnHwqOSiT1lfsvzozmtopduY/edit?tab=t.0#heading=h.jwl49ixv16ap
+- [ ] **Trinity Approach**
+      These three people are responsible for the lifecycle of the epic:
+      UX / QA: A desirable solution, one what your customer really needs.
+      Tech/Architect Expert: A feasible solution, building on the strengths of your current operational capabilities.
+      PO: A viable (profitable) solution, with a sustainable business model.
+      https://docs.google.com/document/d/1nbKJWM_FspoZzlSmbCFTnHwqOSiT1lfsvzozmtopduY/edit?tab=t.0#heading=h.jwl49ixv16ap


### PR DESCRIPTION
While creating new ticket in GH issues I noticed that links in the template were pointing to old Playbook v1, I updated links to tidy it up.  